### PR TITLE
🎨ENC: Supporting Expand/Collapse for Suite Spec Tests based on Pass/Fail

### DIFF
--- a/src/components/appui/testdetails/HistoryTab.tsx
+++ b/src/components/appui/testdetails/HistoryTab.tsx
@@ -2,15 +2,16 @@
 
 import { TabsContent } from "@/components/ui/tabs";
 import { TestHistoryTrendChart } from "@/components/charts/testHistoryTrend";
+import type { TestHistory } from "@/lib/types/OrtoniReportData";
 
-export function HistoryTab({ history }: { history?: any }) {
-  if (!history) {
-    return <p className="text-center">No history found for this test</p>;
-  }
-
+export function HistoryTab({ history }: { history?: TestHistory }) {
   return (
     <TabsContent value="history" className="space-y-6">
-      <TestHistoryTrendChart history={history.history ?? []} />
+      {history ? (
+        <TestHistoryTrendChart history={history.history ?? []} />
+      ) : (
+        <p className="text-center">No history found for this test</p>
+      )}
     </TabsContent>
   );
 }

--- a/src/components/appui/testdetails/StepsTab.tsx
+++ b/src/components/appui/testdetails/StepsTab.tsx
@@ -1,76 +1,130 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { EllipsisBlock } from "@/components/ui/ellipsis-block";
 import { TabsContent } from "@/components/ui/tabs";
 import type { Steps, TestStatus } from "@/lib/types/OrtoniReportData";
 import { StatusPill } from "../common/statuspill";
 import { decodeHtmlEntities, formatIfJson } from "@/lib/utils";
 
-function renderStepsRecursive(steps: Steps[], level = 0) {
-  return steps.map((s, index) => {
-    // ... numbering and indent ...
-    const indent = Array(level).fill("  ").join("");
-    const numbering = `${index + 1}.`;
+/**
+ * Recursively checks whether a step or any of its descendants
+ * contains an error snippet. Used to auto-expand only the steps
+ * relevant to a failure.
+ */
+function hasErrorInTree(step: Steps): boolean {
+  if (step.snippet) return true;
+  return step.steps?.some(hasErrorInTree) ?? false;
+}
 
-    return (
-      <div key={index} className="mb-1">
-        <div className="flex items-start gap-2 justify-between">
-          <div className="flex items-start gap-2 flex-1">
-            <span className="whitespace-pre">
-              {indent}
-              {numbering}
-            </span>
+function StepItem({
+  s,
+  index,
+  level,
+  testStatus,
+}: {
+  s: Steps;
+  index: number;
+  level: number;
+  /** The overall test status — drives the initial expand/collapse state. */
+  testStatus: TestStatus;
+}) {
+  // Only test.step categories with children get the expand/collapse toggle.
+  const hasSubSteps =
+    s.category === "test.step" && s.steps && s.steps.length > 0;
 
-            <div className="flex flex-col flex-1">
-              <div className="flex items-center gap-2">
-                <span
-                  className={
-                    s.snippet ? "text-destructive font-medium" : undefined
-                  }
+  /**
+   * Smart initial expansion:
+   * - Passed test  → all groups start collapsed (no noise).
+   * - Failed test  → only groups that contain an error in their subtree
+   *   start expanded, so the failure path is immediately visible.
+   */
+  const initialExpanded =
+    testStatus === "passed" ? false : hasErrorInTree(s);
+
+  const [expanded, setExpanded] = useState(initialExpanded);
+
+  const indent = Array(level).fill("  ").join("");
+  const numbering = `${index + 1}.`;
+
+  return (
+    <div className="mb-1">
+      <div className="flex items-start gap-2 justify-between">
+        <div className="flex items-start gap-2 flex-1">
+          <span className="whitespace-pre">
+            {indent}
+            {numbering}
+          </span>
+
+          <div className="flex flex-col flex-1">
+            <div className="flex items-center gap-2">
+              {/* Chevron toggle — only rendered for steps that have sub-steps */}
+              {hasSubSteps && (
+                <button
+                  onClick={() => setExpanded((e) => !e)}
+                  className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+                  aria-label={expanded ? "Collapse" : "Expand"}
                 >
-                  {s.title}
-                </span>
-              </div>
-
-              {s.snippet && (
-                <pre
-                  className="text-sm text-muted-foreground whitespace-pre-wrap font-mono p-2 bg-muted/10 rounded mt-1"
-                  dangerouslySetInnerHTML={{
-                    __html: formatIfJson(decodeHtmlEntities(s.snippet)),
-                  }}
-                />
+                  <ChevronRight
+                    className={`size-3.5 transition-transform ${expanded ? "rotate-90" : ""}`}
+                  />
+                </button>
               )}
-            </div>
-          </div>
-          {/* ... duration and status ... */}
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {s.duration && (
-              <span className="text-muted-foreground text-xs">
-                {s.duration} ms
+              <span
+                className={
+                  s.snippet ? "text-destructive font-medium" : undefined
+                }
+              >
+                {s.title}
               </span>
-            )}
+            </div>
 
-            {s.status && (
-              <StatusPill status={s.status as TestStatus} size="xs" />
+            {/* Error snippet — shown inline below the step title when present */}
+            {s.snippet && (
+              <pre
+                className="text-sm text-muted-foreground whitespace-pre-wrap font-mono p-2 bg-muted/10 rounded mt-1"
+                dangerouslySetInnerHTML={{
+                  __html: formatIfJson(decodeHtmlEntities(s.snippet)),
+                }}
+              />
             )}
           </div>
         </div>
-        {/* ... recursive steps ... */}
-        {s.steps && s.category === "test.step" && s.steps.length > 0 && (
-          <div>{renderStepsRecursive(s.steps, level + 1)}</div>
-        )}
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {s.duration && (
+            <span className="text-muted-foreground text-xs">
+              {s.duration} ms
+            </span>
+          )}
+          {s.status && (
+            <StatusPill status={s.status as TestStatus} size="xs" />
+          )}
+        </div>
       </div>
-    );
-  });
+
+      {/* Recursively render nested steps when expanded */}
+      {hasSubSteps && expanded && (
+        <div>{renderStepsRecursive(s.steps!, level + 1, testStatus)}</div>
+      )}
+    </div>
+  );
 }
 
-export function StepsTab({ steps }: { steps: Steps[] }) {
+function renderStepsRecursive(steps: Steps[], level = 0, testStatus: TestStatus = "passed") {
+  return steps.map((s, index) => (
+    <StepItem key={index} s={s} index={index} level={level} testStatus={testStatus} />
+  ));
+}
+
+export function StepsTab({ steps, testStatus }: { steps: Steps[]; testStatus: TestStatus }) {
   if (!steps?.length) return null;
 
   return (
     <TabsContent value="steps">
       <EllipsisBlock title="Test Steps" key="steps">
-        {renderStepsRecursive(steps)}
+        {renderStepsRecursive(steps, 0, testStatus)}
       </EllipsisBlock>
     </TabsContent>
   );

--- a/src/components/appui/testdetails/TestTabs.tsx
+++ b/src/components/appui/testdetails/TestTabs.tsx
@@ -77,7 +77,7 @@ export function TestTabs({
           </TabsTrigger>
         </TabsList>
 
-        <StepsTab steps={test.steps} />
+        <StepsTab steps={test.steps} testStatus={test.status} />
         <ErrorsTab test={test} />
         <LogsTab logs={test.logs} />
         <RetryTab attempts={allAttempts} currentKey={test.key} />


### PR DESCRIPTION
Reason For Enhancement: As if you have test.describe() > test() > test.step() > methods calling UI actions. in that case there is a hierarchy of statement comes and making then collapsed gives easy understanding of the scenario for anyone reading the report. Looking forward to you suggestions if any. Hope this helps everyone & aligns your vision as well.

noProject.json
- Add the 'checkout.spec.ts' sample tests data having the test.step() stetements having the playwright ui actions call for verification of done enhancement.

StepsTab.tsx
- Update for the expand/collapse feature using ChevronRight for such steps based on test result passed/failed. Comments should help.

TestTabs.tsx
- Update the call for StepsTab with testStatus which will decide the sub steps would be expanded or collapsed.

Did the verification on local for all 3 cases:
- Direct test normal ui steps: 

<img width="1878" height="833" alt="image" src="https://github.com/user-attachments/assets/b6cdb13c-6679-4cba-ade0-28a11fde16fc" />

- Describe test with status passed which should be having collapsed steps:
<img width="1903" height="803" alt="image" src="https://github.com/user-attachments/assets/f1f1a6b3-fbcc-4dd2-b5d6-74e6e23e9b50" />

- Describe test with status failed which should be having expanded steps:
<img width="1913" height="897" alt="image" src="https://github.com/user-attachments/assets/aa498a29-4a88-4e20-8f0f-f72f6884edfd" />
