### PR TITLE
⚡UP: Make the Test history chart date viewing from left to right, right-end to be recent similar to Analytics

### DIFF
--- a/src/components/charts/testHistoryTrend.tsx
+++ b/src/components/charts/testHistoryTrend.tsx
@@ -43,7 +43,7 @@ export const TestHistoryTrendChart = memo(
       );
     }
 
-    const chartData = history.slice().map((item) => ({
+    const chartData = history.slice().sort((a, b) => new Date(a.run_date).getTime() - new Date(b.run_date).getTime()).map((item) => ({
       label: new Date(item.run_date).toLocaleDateString("en-US", {
         month: "short",
         day: "numeric",


### PR DESCRIPTION
Reason For PR: In 'Analytics' we are having the date viewing from left to right. Currently in Test History tab it is, we need to view from right to left. For the consistency across, raising this. Pls do share your review.

testHistoryTrend.tsx
- Update chartData by sorting to show it the recent at last.

Validated the same in local for Test History:
<img width="1915" height="837" alt="image" src="https://github.com/user-attachments/assets/cd366934-83f8-491f-9696-659a201a0e8e" />
